### PR TITLE
Refactor websocket to use mock-socket

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "cors": "^2.8.5",
         "express": "^5.1.0",
         "libsodium-wrappers": "^0.7.15",
+        "mock-socket": "^9.3.1",
         "node-mocks-http": "^1.17.2",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
@@ -4288,6 +4289,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mock-socket": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/mock-socket/-/mock-socket-9.3.1.tgz",
+      "integrity": "sha512-qxBgB7Qa2sEQgHFjj0dSigq7fX4k6Saisd5Nelwp2q8mlbAFh5dHV9JTTlF8viYJLSSWgMCZFUom8PJcMNBoJw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "cors": "^2.8.5",
     "express": "^5.1.0",
     "libsodium-wrappers": "^0.7.15",
+    "mock-socket": "^9.3.1",
     "node-mocks-http": "^1.17.2",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",

--- a/tunnel/ServerRAWebSocket.ts
+++ b/tunnel/ServerRAWebSocket.ts
@@ -1,82 +1,134 @@
 import { EventEmitter } from "events"
+import { Server as MockServer, WebSocket as MockWebSocket } from "mock-socket"
 
-// Mock WebSocket exposed to applications
-export class ServerRAMockWebSocket extends EventEmitter {
-  public readonly CONNECTING = 0
-  public readonly OPEN = 1
-  public readonly CLOSING = 2
-  public readonly CLOSED = 3
+// NOTE: The legacy custom mocks are intentionally commented out in favor of mock-socket.
+//
+// export class ServerRAMockWebSocket extends EventEmitter { /* ...legacy implementation... */ }
+// export class ServerRAMockWebSocketServer extends EventEmitter { /* ...legacy implementation... */ }
 
-  public readyState = this.OPEN
+/**
+ * New mock-socket-based WebSocketServer exposed to application code.
+ * Provides a Node ws-like interface with a `clients` Set and `on('connection', ...)`.
+ */
+export class NewServerRAMockWebSocketServer {
+  public readonly url: string
+  private readonly server: MockServer
+  public readonly clients: Set<any> = new Set()
 
-  private onSendToClient: (data: string | Buffer) => void
-  private onCloseToClient: (code?: number, reason?: string) => void
+  constructor(url?: string) {
+    // Use a unique in-memory URL if not provided
+    this.url = url ?? `ws://ra-mock-${Math.random().toString(36).slice(2)}`
+    const previousGlobalWebSocket = (globalThis as any).WebSocket
+    this.server = new MockServer(this.url)
+    // Restore any pre-existing global WebSocket to avoid intercepting real sockets
+    try {
+      ;(globalThis as any).WebSocket = previousGlobalWebSocket
+    } catch {}
 
-  constructor(
-    onSendToClient: (data: string | Buffer) => void,
-    onCloseToClient: (code?: number, reason?: string) => void,
-  ) {
-    super()
-    this.onSendToClient = onSendToClient
-    this.onCloseToClient = onCloseToClient
+    // Track connected clients for app-level broadcasting
+    this.server.on("connection", (socket: any) => {
+      this.clients.add(socket)
+      try {
+        socket.on("close", () => {
+          this.clients.delete(socket)
+        })
+      } catch {}
+    })
   }
 
-  send(data: string | Buffer): void {
-    if (this.readyState !== this.OPEN) return
-    this.onSendToClient(data)
+  on(event: string, listener: (...args: any[]) => void): this {
+    // Forward event subscription to underlying mock-socket server
+    ;(this.server as any).on(event, listener)
+    return this
   }
 
-  close(code?: number, reason?: string): void {
-    if (this.readyState === this.CLOSING || this.readyState === this.CLOSED) {
-      return
-    }
-    this.readyState = this.CLOSING
-    // Inform client then mark closed locally
-    this.onCloseToClient(code, reason)
-    this.emitClose(code, reason)
-  }
-
-  // Methods used by RA to inject events from client
-  emitMessage(data: string | Buffer): void {
-    if (this.readyState !== this.OPEN) return
-    const payload = typeof data === "string" ? data : Buffer.from(data)
-    this.emit("message", payload as any)
-  }
-
-  emitClose(code?: number, reason?: string): void {
-    if (this.readyState === this.CLOSED) return
-    this.readyState = this.CLOSED
-    this.emit("close", code ?? 1000, reason ?? "")
-  }
-
-  public emit(eventName: string | symbol, ...args: any[]): boolean {
-    return super.emit(eventName as any, ...args)
-  }
-}
-
-// Mock WebSocketServer exposed to application code
-export class ServerRAMockWebSocketServer extends EventEmitter {
-  public clients: Set<ServerRAMockWebSocket> = new Set()
-
-  addClient(ws: ServerRAMockWebSocket): void {
-    this.clients.add(ws)
-    this.emit("connection", ws)
-  }
-
-  deleteClient(ws: ServerRAMockWebSocket): void {
-    this.clients.delete(ws)
+  off(event: string, listener: (...args: any[]) => void): this {
+    ;(this.server as any).off?.(event, listener)
+    return this
   }
 
   close(cb?: () => void): void {
     try {
-      for (const ws of Array.from(this.clients)) {
+      // Close all clients first so application sees close events
+      for (const client of Array.from(this.clients)) {
         try {
-          ws.close(1000, "server closing")
+          client.close(1000, "server closing")
         } catch {}
       }
       this.clients.clear()
     } finally {
+      try {
+        this.server.stop({ immediate: true } as any)
+      } catch {}
       if (cb) cb()
     }
+  }
+}
+
+/**
+ * New mock-socket-based WebSocket used internally by RA to bridge
+ * tunnel messages to the application server via the in-memory server.
+ */
+export class NewServerRAMockWebSocket {
+  private readonly socket: MockWebSocket
+  private readonly pendingSends: Array<string | ArrayBuffer | Buffer> = []
+
+  constructor(
+    url: string,
+    onAppSend: (data: string | Buffer) => void,
+    onAppClose: (code?: number, reason?: string) => void,
+  ) {
+    this.socket = new MockWebSocket(url)
+
+    ;(this.socket as any).onopen = () => {
+      // Flush any queued messages from remote to application once open
+      try {
+        for (const item of this.pendingSends.splice(0)) {
+          this.socket.send(item as any)
+        }
+      } catch {}
+    }
+
+    // Application -> Client path: The app calls serverSocket.send(data),
+    // which is received by this client as a message event.
+    ;(this.socket as any).onmessage = (event: any) => {
+      const data: any = event?.data
+      if (typeof data === "string") {
+        onAppSend(data)
+      } else if (data instanceof ArrayBuffer) {
+        onAppSend(Buffer.from(new Uint8Array(data)))
+      } else if (typeof Buffer !== "undefined" && Buffer.isBuffer?.(data)) {
+        onAppSend(data as Buffer)
+      } else {
+        try {
+          onAppSend(String(data))
+        } catch {
+          onAppSend("")
+        }
+      }
+    }
+
+    // Application -> Client close path: When the app closes the server-side
+    // socket, the client observes a close event.
+    ;(this.socket as any).onclose = (event: any) => {
+      const code = event?.code as number | undefined
+      const reason = event?.reason as string | undefined
+      onAppClose(code, reason)
+    }
+  }
+
+  /** Remote -> Application: deliver a message to the app. */
+  public deliverToApplication(data: string | Buffer): void {
+    const payload: string | Buffer = typeof data === "string" ? data : data
+    if ((this.socket as any).readyState === 1) {
+      this.socket.send(payload as any)
+    } else {
+      this.pendingSends.push(payload)
+    }
+  }
+
+  /** Remote -> Application: close the connection visible to the app. */
+  public closeApplicationView(code?: number, reason?: string): void {
+    ;(this.socket as any).close(code, reason)
   }
 }


### PR DESCRIPTION
Refactor WebSocket mocking to use `mock-socket` for improved reliability and maintainability.

---
<a href="https://cursor.com/background-agent?bcId=bc-7ff73a42-afb3-47ef-8e2a-2a5736399bd0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7ff73a42-afb3-47ef-8e2a-2a5736399bd0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

