### PR TITLE
Refactor websocket to use mock-socket

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "cors": "^2.8.5",
         "express": "^5.1.0",
         "libsodium-wrappers": "^0.7.15",
+        "mock-socket": "^9.3.1",
         "node-mocks-http": "^1.17.2",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
@@ -4288,6 +4289,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mock-socket": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/mock-socket/-/mock-socket-9.3.1.tgz",
+      "integrity": "sha512-qxBgB7Qa2sEQgHFjj0dSigq7fX4k6Saisd5Nelwp2q8mlbAFh5dHV9JTTlF8viYJLSSWgMCZFUom8PJcMNBoJw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "cors": "^2.8.5",
     "express": "^5.1.0",
     "libsodium-wrappers": "^0.7.15",
+    "mock-socket": "^9.3.1",
     "node-mocks-http": "^1.17.2",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",

--- a/tunnel/ServerRAWebSocket.ts
+++ b/tunnel/ServerRAWebSocket.ts
@@ -1,13 +1,20 @@
 import { EventEmitter } from "events"
+import { Server as MockSocketServer, WebSocket as MockSocketWebSocket } from "mock-socket"
 
-// Mock WebSocket exposed to applications
-export class ServerRAMockWebSocket extends EventEmitter {
+// NOTE: The previous custom mocks are intentionally commented out in favor of mock-socket-based implementations below.
+// export class ServerRAMockWebSocket extends EventEmitter { /* ...custom mock... */ }
+// export class ServerRAMockWebSocketServer extends EventEmitter { /* ...custom mock server... */ }
+
+export class NewServerRAMockWebSocket extends EventEmitter {
   public readonly CONNECTING = 0
   public readonly OPEN = 1
   public readonly CLOSING = 2
   public readonly CLOSED = 3
 
-  public readyState = this.OPEN
+  public readyState = this.CONNECTING
+
+  private serverSocket: MockSocketWebSocket | null = null
+  private clientSocket: MockSocketWebSocket | null = null
 
   private onSendToClient: (data: string | Buffer) => void
   private onCloseToClient: (code?: number, reason?: string) => void
@@ -21,9 +28,47 @@ export class ServerRAMockWebSocket extends EventEmitter {
     this.onCloseToClient = onCloseToClient
   }
 
+  // Called by NewServerRAMockWebSocketServer when pairing sockets
+  attachServerSocket(serverSocket: MockSocketWebSocket, clientSocket: MockSocketWebSocket): void {
+    this.serverSocket = serverSocket
+    this.clientSocket = clientSocket
+    this.readyState = this.OPEN
+
+    // Application -> Remote: when app sends using this wrapper, we intercept in send()
+    // Remote -> Application: forward messages arriving on server socket to app listeners
+    this.serverSocket.addEventListener("message", (evt: any) => {
+      const data = (evt && (evt.data ?? evt)) as any
+      const payload = typeof data === "string" ? data : Buffer.from(data as any)
+      if (this.readyState === this.OPEN) {
+        this.emit("message", payload as any)
+      }
+    })
+
+    // When the server-side socket is closed, notify app listeners
+    this.serverSocket.addEventListener("close", (evt: any) => {
+      const code = evt && typeof evt.code === "number" ? evt.code : 1000
+      const reason = evt && typeof evt.reason === "string" ? evt.reason : ""
+      if (this.readyState !== this.CLOSED) {
+        this.readyState = this.CLOSED
+        this.emit("close", code, reason)
+      }
+    })
+  }
+
+  // Connects the internal client socket to a given server URL
+  connectTo(url: string): void {
+    // Create client which will trigger a server-side connection
+    this.clientSocket = new MockSocketWebSocket(url)
+  }
+
   send(data: string | Buffer): void {
     if (this.readyState !== this.OPEN) return
+    // Inform the remote client via provided callback
     this.onSendToClient(data)
+    // Also forward through the mock server socket for completeness
+    try {
+      this.serverSocket?.send(data as any)
+    } catch {}
   }
 
   close(code?: number, reason?: string): void {
@@ -31,39 +76,82 @@ export class ServerRAMockWebSocket extends EventEmitter {
       return
     }
     this.readyState = this.CLOSING
-    // Inform client then mark closed locally
-    this.onCloseToClient(code, reason)
+    // Inform remote then close locally
+    try {
+      this.onCloseToClient(code, reason)
+    } catch {}
+    try {
+      this.serverSocket?.close()
+    } catch {}
     this.emitClose(code, reason)
   }
 
   // Methods used by RA to inject events from client
   emitMessage(data: string | Buffer): void {
     if (this.readyState !== this.OPEN) return
-    const payload = typeof data === "string" ? data : Buffer.from(data)
-    this.emit("message", payload as any)
+    try {
+      // Route via client side to trigger server-side "message"
+      this.clientSocket?.send(data as any)
+    } catch {
+      // Fallback: emit directly
+      const payload = typeof data === "string" ? data : Buffer.from(data)
+      this.emit("message", payload as any)
+    }
   }
 
   emitClose(code?: number, reason?: string): void {
     if (this.readyState === this.CLOSED) return
+    try {
+      this.clientSocket?.close()
+    } catch {}
     this.readyState = this.CLOSED
     this.emit("close", code ?? 1000, reason ?? "")
   }
-
-  public emit(eventName: string | symbol, ...args: any[]): boolean {
-    return super.emit(eventName as any, ...args)
-  }
 }
 
-// Mock WebSocketServer exposed to application code
-export class ServerRAMockWebSocketServer extends EventEmitter {
-  public clients: Set<ServerRAMockWebSocket> = new Set()
+export class NewServerRAMockWebSocketServer extends EventEmitter {
+  public clients: Set<NewServerRAMockWebSocket> = new Set()
 
-  addClient(ws: ServerRAMockWebSocket): void {
-    this.clients.add(ws)
-    this.emit("connection", ws)
+  private server: MockSocketServer
+  private url: string
+  private pendingWrappers: NewServerRAMockWebSocket[] = []
+
+  constructor() {
+    super()
+    // Use a unique URL namespace per instance
+    const uid = Math.random().toString(36).slice(2)
+    this.url = `ws://ra-mock/${uid}`
+    this.server = new MockSocketServer(this.url)
+
+    this.server.on("connection", (serverSocket: any) => {
+      // Pair with the next pending wrapper added by addClient()
+      const wrapper = this.pendingWrappers.shift()
+      if (!wrapper) {
+        try {
+          serverSocket.close()
+        } catch {}
+        return
+      }
+      // Ensure wrapper has a client socket created
+      if (!wrapper["clientSocket"]) {
+        // Should not happen, but ensure a client exists
+        try {
+          ;(wrapper as any).connectTo(this.url)
+        } catch {}
+      }
+      wrapper.attachServerSocket(serverSocket, (wrapper as any).clientSocket)
+      this.clients.add(wrapper)
+      this.emit("connection", wrapper)
+    })
   }
 
-  deleteClient(ws: ServerRAMockWebSocket): void {
+  addClient(ws: NewServerRAMockWebSocket): void {
+    this.pendingWrappers.push(ws)
+    // Trigger a connection by connecting the internal client
+    ws.connectTo(this.url)
+  }
+
+  deleteClient(ws: NewServerRAMockWebSocket): void {
     this.clients.delete(ws)
   }
 
@@ -75,6 +163,9 @@ export class ServerRAMockWebSocketServer extends EventEmitter {
         } catch {}
       }
       this.clients.clear()
+      try {
+        this.server.stop()
+      } catch {}
     } finally {
       if (cb) cb()
     }

--- a/tunnel/server.ts
+++ b/tunnel/server.ts
@@ -15,8 +15,8 @@ import {
 } from "./types.js"
 import { parseBody, sanitizeHeaders, getStatusText } from "./utils/server.js"
 import {
-  ServerRAMockWebSocket,
-  ServerRAMockWebSocketServer,
+  NewServerRAMockWebSocket,
+  NewServerRAMockWebSocketServer,
 } from "./ServerRAWebSocket.js"
 
 export class RA {
@@ -29,7 +29,7 @@ export class RA {
 
   private webSocketConnections = new Map<
     string,
-    { mockWs: ServerRAMockWebSocket; controlWs: WebSocket }
+    { mockWs: NewServerRAMockWebSocket; controlWs: WebSocket }
   >()
   private symmetricKeyBySocket = new Map<WebSocket, Uint8Array>()
 
@@ -44,7 +44,7 @@ export class RA {
     this.server = http.createServer(app)
 
     // Expose a mock WebSocketServer to application code
-    this.wss = new ServerRAMockWebSocketServer()
+    this.wss = new NewServerRAMockWebSocketServer()
 
     // Route upgrades to the control channel WebSocketServer
     this.controlWss = new WebSocketServer({ noServer: true })
@@ -356,7 +356,7 @@ export class RA {
       }
 
       // Create a mock socket and expose it to application via mock server
-      const mock = new ServerRAMockWebSocket(
+      const mock = new NewServerRAMockWebSocket(
         // onSend: application -> client
         (payload) => {
           let messageData: string


### PR DESCRIPTION
Replace custom WebSocket mocks with `mock-socket` for better test reliability and maintainability.

---
<a href="https://cursor.com/background-agent?bcId=bc-d3ee3c61-f74a-42fb-a5dd-05e499c6c4e2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d3ee3c61-f74a-42fb-a5dd-05e499c6c4e2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

