### PR TITLE
Replace typed-struct with binary-parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@peculiar/webcrypto": "^1.5.0",
         "@peculiar/x509": "^1.14.0",
+        "@types/binary-parser": "^1.5.5",
+        "binary-parser": "^2.2.1",
         "cors": "^2.8.5",
         "express": "^5.1.0",
         "jsonwebtoken": "^9.0.2",
@@ -18,7 +20,6 @@
         "node-mocks-http": "^1.17.2",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
-        "typed-struct": "^2.6.0",
         "webcrypto-liner": "^1.4.3",
         "ws": "^8.18.3"
       },
@@ -1859,6 +1860,15 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/binary-parser": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@types/binary-parser/-/binary-parser-1.5.5.tgz",
+      "integrity": "sha512-HL2Q9Q0JPlgQQX7JFgCIkofUw6jfUnP4WoBRlgF4yhPxLN2hfzaN5VNBQBq0cHD3+V4WBlJQuf/Lk2zdCKuGAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -2465,7 +2475,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2481,6 +2491,15 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/binary-parser": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/binary-parser/-/binary-parser-2.2.1.tgz",
+      "integrity": "sha512-5ATpz/uPDgq5GgEDxTB4ouXCde7q2lqAQlSdBRQVl/AJnxmQmhIfyxJx+0MGu//D5rHQifkfGbWWlaysG0o9NA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/bindings": {
       "version": "1.5.0",
@@ -2706,7 +2725,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
       "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4543,7 +4562,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7431,31 +7450,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/typed-struct": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/typed-struct/-/typed-struct-2.6.0.tgz",
-      "integrity": "sha512-xs/AjORbEAG21wlq1+ax7kBysad9O3p2NZkf82VV2endZ3lS/rCHmT6BH2wuZvxKwLWIg6zcWT4RJWBU/r4+qw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "buffer": "^6.0.3",
-        "debug": "^4.3.3",
-        "iconv-lite": "^0.6.3"
-      },
-      "peerDependenciesMeta": {
-        "buffer": {
-          "optional": true
-        },
-        "debug": {
-          "optional": true
-        },
-        "iconv-lite": {
-          "optional": true
-        }
       }
     },
     "node_modules/typescript": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
   "dependencies": {
     "@peculiar/webcrypto": "^1.5.0",
     "@peculiar/x509": "^1.14.0",
+    "@types/binary-parser": "^1.5.5",
+    "binary-parser": "^2.2.1",
     "cors": "^2.8.5",
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
@@ -24,7 +26,6 @@
     "node-mocks-http": "^1.17.2",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
-    "typed-struct": "^2.6.0",
     "webcrypto-liner": "^1.4.3",
     "ws": "^8.18.3"
   },

--- a/qvl/formatters.ts
+++ b/qvl/formatters.ts
@@ -4,10 +4,9 @@ import {
   TdxQuoteBody_1_5,
   TdxSignature,
 } from "./structs.js"
-import { ExtractType } from "typed-struct"
 import { hex } from "./utils.js"
 
-export const formatTDXHeader = (header: ExtractType<typeof QuoteHeader>) => {
+export const formatTDXHeader = (header: ReturnType<typeof QuoteHeader.parse>) => {
   return {
     version: header.version,
     att_key_type: header.att_key_type,
@@ -21,8 +20,8 @@ export const formatTDXHeader = (header: ExtractType<typeof QuoteHeader>) => {
 
 export const formatTDXQuoteBodyV4 = (
   report:
-    | ExtractType<typeof TdxQuoteBody_1_0>
-    | InstanceType<typeof TdxQuoteBody_1_5>,
+    | ReturnType<typeof TdxQuoteBody_1_0.parse>
+    | ReturnType<typeof TdxQuoteBody_1_5.parse>,
 ) => {
   return {
     seam_svn: report.seam_svn,

--- a/qvl/structs.ts
+++ b/qvl/structs.ts
@@ -1,121 +1,111 @@
-import { ExtractType, Struct } from "typed-struct"
+import { Parser } from "binary-parser"
 
-export const QuoteHeader = new Struct("QuoteHeader")
-  .UInt16LE("version")
-  .UInt16LE("att_key_type")
-  .UInt32LE("tee_type")
-  .UInt16LE("qe_svn")
-  .UInt16LE("pce_svn")
-  .Buffer("qe_vendor_id", 16)
-  .Buffer("user_data", 20)
-  .compile()
+export const QuoteHeader = new Parser()
+  .uint16le("version")
+  .uint16le("att_key_type")
+  .uint32le("tee_type")
+  .uint16le("qe_svn")
+  .uint16le("pce_svn")
+  .buffer("qe_vendor_id", { length: 16 })
+  .buffer("user_data", { length: 20 })
 
-export const SgxReportBody = new Struct("SgxReportBody")
-  .Buffer("cpu_svn", 16)
-  .UInt32LE("misc_select")
-  .Buffer("reserved1", 28)
-  .Buffer("attributes", 16)
-  .Buffer("mr_enclave", 32)
-  .Buffer("reserved2", 32)
-  .Buffer("mr_signer", 32)
-  .Buffer("reserved3", 96)
-  .UInt16LE("isv_prod_id")
-  .UInt16LE("isv_svn")
-  .Buffer("reserved4", 60)
-  .Buffer("report_data", 64)
-  .compile()
+export const SgxReportBody = new Parser()
+  .buffer("cpu_svn", { length: 16 })
+  .uint32le("misc_select")
+  .buffer("reserved1", { length: 28 })
+  .buffer("attributes", { length: 16 })
+  .buffer("mr_enclave", { length: 32 })
+  .buffer("reserved2", { length: 32 })
+  .buffer("mr_signer", { length: 32 })
+  .buffer("reserved3", { length: 96 })
+  .uint16le("isv_prod_id")
+  .uint16le("isv_svn")
+  .buffer("reserved4", { length: 60 })
+  .buffer("report_data", { length: 64 })
 
-export const TdxQuoteBody_1_0 = new Struct("TdxQuoteBodyV1_0")
-  .Buffer("tee_tcb_svn", 16)
-  .Buffer("mr_seam", 48)
-  .Buffer("mr_seam_signer", 48)
-  .UInt32LE("seam_svn")
-  .UInt32LE("reserved0")
-  .Buffer("td_attributes", 8)
-  .Buffer("xfam", 8)
-  .Buffer("mr_td", 48)
-  .Buffer("mr_config_id", 48)
-  .Buffer("mr_owner", 48)
-  .Buffer("mr_owner_config", 48)
-  .Buffer("rtmr0", 48)
-  .Buffer("rtmr1", 48)
-  .Buffer("rtmr2", 48)
-  .Buffer("rtmr3", 48)
-  .Buffer("report_data", 64)
-  .compile()
+export const TdxQuoteBody_1_0 = new Parser()
+  .buffer("tee_tcb_svn", { length: 16 })
+  .buffer("mr_seam", { length: 48 })
+  .buffer("mr_seam_signer", { length: 48 })
+  .uint32le("seam_svn")
+  .uint32le("reserved0")
+  .buffer("td_attributes", { length: 8 })
+  .buffer("xfam", { length: 8 })
+  .buffer("mr_td", { length: 48 })
+  .buffer("mr_config_id", { length: 48 })
+  .buffer("mr_owner", { length: 48 })
+  .buffer("mr_owner_config", { length: 48 })
+  .buffer("rtmr0", { length: 48 })
+  .buffer("rtmr1", { length: 48 })
+  .buffer("rtmr2", { length: 48 })
+  .buffer("rtmr3", { length: 48 })
+  .buffer("report_data", { length: 64 })
 
-export const TdxQuoteBody_1_5 = new Struct("TdxQuoteBodyV1_5")
-  .Buffer("tee_tcb_svn", 16)
-  .Buffer("mr_seam", 48)
-  .Buffer("mr_seam_signer", 48)
-  .UInt32LE("seam_svn")
-  .UInt32LE("reserved0")
-  .Buffer("td_attributes", 8)
-  .Buffer("xfam", 8)
-  .Buffer("mr_td", 48)
-  .Buffer("mr_config_id", 48)
-  .Buffer("mr_owner", 48)
-  .Buffer("mr_owner_config", 48)
-  .Buffer("rtmr0", 48)
-  .Buffer("rtmr1", 48)
-  .Buffer("rtmr2", 48)
-  .Buffer("rtmr3", 48)
-  .Buffer("report_data", 64)
-  .Buffer("tee_tcb_svn_2", 16) // appended
-  .Buffer("mrservictd", 48) // appended
-  .compile()
+export const TdxQuoteBody_1_5 = new Parser()
+  .buffer("tee_tcb_svn", { length: 16 })
+  .buffer("mr_seam", { length: 48 })
+  .buffer("mr_seam_signer", { length: 48 })
+  .uint32le("seam_svn")
+  .uint32le("reserved0")
+  .buffer("td_attributes", { length: 8 })
+  .buffer("xfam", { length: 8 })
+  .buffer("mr_td", { length: 48 })
+  .buffer("mr_config_id", { length: 48 })
+  .buffer("mr_owner", { length: 48 })
+  .buffer("mr_owner_config", { length: 48 })
+  .buffer("rtmr0", { length: 48 })
+  .buffer("rtmr1", { length: 48 })
+  .buffer("rtmr2", { length: 48 })
+  .buffer("rtmr3", { length: 48 })
+  .buffer("report_data", { length: 64 })
+  .buffer("tee_tcb_svn_2", { length: 16 }) // appended
+  .buffer("mrservictd", { length: 48 }) // appended
 
-export const SgxQuote = new Struct("SgxQuote")
-  .Struct("header", QuoteHeader)
-  .Struct("body", SgxReportBody)
-  .UInt32LE("sig_data_len")
-  .Buffer("sig_data")
-  .compile()
+export const SgxQuote = new Parser()
+  .nest("header", { type: QuoteHeader })
+  .nest("body", { type: SgxReportBody })
+  .uint32le("sig_data_len")
+  .buffer("sig_data", { length: function() { return this.sig_data_len } })
 
-export const SgxTail = new Struct("SgxTail")
-  .UInt16LE("cert_data_type")
-  .UInt32LE("cert_data_len")
-  .Buffer("cert_data")
-  .compile()
+export const SgxTail = new Parser()
+  .uint16le("cert_data_type")
+  .uint32le("cert_data_len")
+  .buffer("cert_data", { length: function() { return this.cert_data_len } })
 
-export const TdxQuoteV4 = new Struct("TdxQuoteV4")
-  .Struct("header", QuoteHeader)
-  .Struct("body", TdxQuoteBody_1_0)
-  .UInt32LE("sig_data_len")
-  .Buffer("sig_data")
-  .compile()
+export const TdxQuoteV4 = new Parser()
+  .nest("header", { type: QuoteHeader })
+  .nest("body", { type: TdxQuoteBody_1_0 })
+  .uint32le("sig_data_len")
+  .buffer("sig_data", { length: function() { return this.sig_data_len } })
 
-export const TdxQuoteV5Descriptor = new Struct("TdxQuoteV5BodyDescriptor")
-  .Struct("header", QuoteHeader)
-  .UInt16LE("body_type")
-  .UInt32LE("body_size")
-  .Buffer("extra")
-  .compile()
+export const TdxQuoteV5Descriptor = new Parser()
+  .nest("header", { type: QuoteHeader })
+  .uint16le("body_type")
+  .uint32le("body_size")
+  .buffer("extra", { readUntil: "eof" })
 
-export const TdxQuoteV5SigDescriptor = new Struct("TdxQuoteV5SigDescriptor")
-  .UInt32LE("sig_data_len")
-  .Buffer("sig_data")
-  .compile()
+export const TdxQuoteV5SigDescriptor = new Parser()
+  .uint32le("sig_data_len")
+  .buffer("sig_data", { length: function() { return this.sig_data_len } })
 
 /**
  * SGX signatures contain a fixed-length ECDSA signature section, and
  * a variable-length cert_data tail.
  */
 export function parseSgxSignature(quote: Buffer) {
-  const { sig_data } = new SgxQuote(quote)
+  const { sig_data } = SgxQuote.parse(quote)
 
-  const EcdsaSignatureFixed = new Struct("EcdsaSignatureFixed")
-    .Buffer("signature", 64)
-    .Buffer("attestation_public_key", 64)
-    .Buffer("qe_report", 384)
-    .Buffer("qe_report_signature", 64)
-    .UInt16LE("qe_auth_data_len")
-    .Buffer("extra")
-    .compile()
-  const fixed = new EcdsaSignatureFixed(sig_data)
+  const EcdsaSignatureFixed = new Parser()
+    .buffer("signature", { length: 64 })
+    .buffer("attestation_public_key", { length: 64 })
+    .buffer("qe_report", { length: 384 })
+    .buffer("qe_report_signature", { length: 64 })
+    .uint16le("qe_auth_data_len")
+  const fixed = EcdsaSignatureFixed.parse(sig_data)
 
-  const tail = fixed.extra.subarray(fixed.qe_auth_data_len)
-  const { cert_data_type, cert_data_len, cert_data } = new SgxTail(tail)
+  const qe_auth_data = sig_data.subarray(64 + 64 + 384 + 64 + 2, 64 + 64 + 384 + 64 + 2 + fixed.qe_auth_data_len)
+  const tail = sig_data.subarray(64 + 64 + 384 + 64 + 2 + fixed.qe_auth_data_len)
+  const { cert_data_type, cert_data_len, cert_data } = SgxTail.parse(tail)
 
   return {
     ecdsa_signature: fixed.signature,
@@ -124,7 +114,7 @@ export function parseSgxSignature(quote: Buffer) {
     qe_report_present: !!fixed.qe_report,
     qe_report_signature: fixed.qe_report_signature,
     qe_auth_data_len: fixed.qe_auth_data_len,
-    qe_auth_data: fixed.extra.subarray(0, fixed.qe_auth_data_len),
+    qe_auth_data,
     cert_data_type,
     cert_data_len,
     cert_data: cert_data.subarray(0, cert_data_len),
@@ -139,24 +129,23 @@ export function parseSgxSignature(quote: Buffer) {
 export function parseTdxSignature(quote: Buffer, v5?: boolean) {
   let sig_data
   if (!v5) {
-    sig_data = new TdxQuoteV4(quote).sig_data
+    sig_data = TdxQuoteV4.parse(quote).sig_data
   } else {
-    const { body_size, extra } = new TdxQuoteV5Descriptor(quote)
-    sig_data = new TdxQuoteV5SigDescriptor(extra.subarray(body_size)).sig_data
+    const { body_size, extra } = TdxQuoteV5Descriptor.parse(quote)
+    sig_data = TdxQuoteV5SigDescriptor.parse(extra.subarray(body_size)).sig_data
   }
 
-  const EcdsaSigFixed = new Struct("EcdsaSigFixed")
-    .Buffer("signature", 64)
-    .Buffer("attestation_public_key", 64)
-    .UInt16LE("cert_type")
-    .UInt32LE("cert_size")
-    .Buffer("qe_report", 384)
-    .Buffer("qe_report_signature", 64)
-    .UInt16LE("qe_auth_data_len")
-    .compile()
+  const EcdsaSigFixed = new Parser()
+    .buffer("signature", { length: 64 })
+    .buffer("attestation_public_key", { length: 64 })
+    .uint16le("cert_type")
+    .uint32le("cert_size")
+    .buffer("qe_report", { length: 384 })
+    .buffer("qe_report_signature", { length: 64 })
+    .uint16le("qe_auth_data_len")
 
-  const fixed = new EcdsaSigFixed(sig_data)
-  let offset = EcdsaSigFixed.baseSize
+  const fixed = EcdsaSigFixed.parse(sig_data)
+  let offset = 64 + 64 + 2 + 4 + 384 + 64 + 2 // Calculate fixed size manually
 
   const qe_auth_data = sig_data.subarray(
     offset,
@@ -164,20 +153,18 @@ export function parseTdxSignature(quote: Buffer, v5?: boolean) {
   )
   offset += fixed.qe_auth_data_len
 
-  const Tail = new Struct("Tail")
-    .UInt16LE("cert_data_type")
-    .UInt32LE("cert_data_len")
-    .compile()
+  const Tail = new Parser()
+    .uint16le("cert_data_type")
+    .uint32le("cert_data_len")
 
-  const { cert_data_type, cert_data_len } = new Tail(
-    sig_data.subarray(offset, offset + Tail.baseSize),
+  const { cert_data_type, cert_data_len } = Tail.parse(
+    sig_data.subarray(offset, offset + 6), // 2 + 4 = 6 bytes
   )
-  offset += Tail.baseSize
+  offset += 6
 
-  const CertData = new Struct("CertData")
-    .Buffer("cert_data", cert_data_len)
-    .compile()
-  const { cert_data } = new CertData(sig_data.subarray(offset))
+  const CertData = new Parser()
+    .buffer("cert_data", { length: cert_data_len })
+  const { cert_data } = CertData.parse(sig_data.subarray(offset))
 
   return {
     ecdsa_signature: fixed.signature,
@@ -200,24 +187,26 @@ export type TdxSignature = ReturnType<typeof parseTdxSignature>
  * Compute the signed region of an SGX quote: header || body (excludes sig length and sig_data)
  */
 export function getSgxSignedRegion(quoteBytes: Buffer): Buffer {
-  return quoteBytes.subarray(0, QuoteHeader.baseSize + SgxReportBody.baseSize)
+  // QuoteHeader: 2+2+4+2+2+16+20 = 48 bytes
+  // SgxReportBody: 16+4+28+16+32+32+32+96+2+2+60+64 = 384 bytes
+  return quoteBytes.subarray(0, 48 + 384)
 }
 
 /**
  * Compute the signed region of a TDX 1.0 quote: header || body (excludes sig length and sig_data)
  */
 export function getTdx10SignedRegion(quoteBytes: Buffer): Buffer {
-  const headerLen = QuoteHeader.baseSize as number
-  const bodyLen = TdxQuoteBody_1_0.baseSize as number
-  return quoteBytes.subarray(0, headerLen + bodyLen)
+  // QuoteHeader: 48 bytes
+  // TdxQuoteBody_1_0: 16+48+48+4+4+8+8+48+48+48+48+48+48+48+48+64 = 576 bytes
+  return quoteBytes.subarray(0, 48 + 576)
 }
 
 /**
  * Compute the signed region of a TDX 1.5 quote: header || body_descriptor || body
  */
 export function getTdx15SignedRegion(quoteBytes: Buffer): Buffer {
-  const { body_size } = new TdxQuoteV5Descriptor(quoteBytes)
-  const headerLen = QuoteHeader.baseSize as number
+  const { body_size } = TdxQuoteV5Descriptor.parse(quoteBytes)
+  const headerLen = 48 // QuoteHeader size
   const totalLen = headerLen + 2 + 4 + body_size
   return quoteBytes.subarray(0, totalLen)
 }
@@ -226,26 +215,26 @@ export function getTdx15SignedRegion(quoteBytes: Buffer): Buffer {
  * Parse a TDX 1.0 or 1.5 quote as header, body, and signature.
  */
 export function parseTdxQuote(quote: Buffer): {
-  header: ExtractType<typeof QuoteHeader>
-  body: ExtractType<typeof TdxQuoteBody_1_0 | typeof TdxQuoteBody_1_5>
+  header: ReturnType<typeof QuoteHeader.parse>
+  body: ReturnType<typeof TdxQuoteBody_1_0.parse> | ReturnType<typeof TdxQuoteBody_1_5.parse>
   signature: TdxSignature
 } {
-  const header = new QuoteHeader(quote)
+  const header = QuoteHeader.parse(quote)
   if (header.version === 4) {
-    const { body } = new TdxQuoteV4(quote)
+    const { body } = TdxQuoteV4.parse(quote)
     const signature = parseTdxSignature(quote)
 
     return { header, body, signature }
   } else if (header.version === 5) {
-    const { body_type, body_size, extra } = new TdxQuoteV5Descriptor(quote)
+    const { body_type, body_size, extra } = TdxQuoteV5Descriptor.parse(quote)
 
     let body
     if (body_type === 1) {
       throw new Error("parseQuote: unexpected body_type = 1")
     } else if (body_type === 2) {
-      body = new TdxQuoteBody_1_0(extra.subarray(0, body_size))
+      body = TdxQuoteBody_1_0.parse(extra.subarray(0, body_size))
     } else if (body_type === 3) {
-      body = new TdxQuoteBody_1_5(extra.subarray(0, body_size))
+      body = TdxQuoteBody_1_5.parse(extra.subarray(0, body_size))
     } else {
       throw new Error("parseQuote: unexpected body_type")
     }
@@ -267,16 +256,16 @@ export function parseTdxQuoteBase64(quote: string) {
  * Parse a TDX 1.0 or 1.5 quote as header, body, and signature.
  */
 export function parseSgxQuote(quote: Buffer): {
-  header: ExtractType<typeof QuoteHeader>
-  body: ExtractType<typeof SgxReportBody>
+  header: ReturnType<typeof QuoteHeader.parse>
+  body: ReturnType<typeof SgxReportBody.parse>
   signature: SgxSignature
 } {
-  const header = new QuoteHeader(quote)
+  const header = QuoteHeader.parse(quote)
   if (header.version !== 3) {
     throw new Error("parseQuote: Unsupported SGX quote version")
   }
 
-  const { body } = new SgxQuote(quote)
+  const { body } = SgxQuote.parse(quote)
   const signature = parseSgxSignature(quote)
 
   return { header, body, signature }


### PR DESCRIPTION
Replace `typed-struct` with `binary-parser` for binary parsing.

This PR migrates the binary parsing logic from `typed-struct` to `binary-parser`. All struct definitions, type annotations, and parsing functions have been updated to use the new library's API. While SGX quote parsing has been verified and is working correctly, TDX quote parsing currently exhibits issues with variable-length buffer handling, resulting in "invalid signature over quote" errors in tests.

---
<a href="https://cursor.com/background-agent?bcId=bc-3d085950-62b8-4264-b16b-9f6356046783"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3d085950-62b8-4264-b16b-9f6356046783"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

