### PR TITLE
Extract PCESVN from PCK certificate extension

### DIFF
--- a/packages/qvl/src/verifySgx.ts
+++ b/packages/qvl/src/verifySgx.ts
@@ -177,11 +177,12 @@ export async function _verifySgx(quote: Uint8Array, config?: VerifyConfig) {
   const parsedQuote = parseSgxQuote(quote)
   const { signature, header } = parsedQuote
   const certs = extractPemCertificates(signature.cert_data)
-  let { status, root, fmspc } = await verifyPCKChain(
+  let { status, root, fmspc, chain } = await verifyPCKChain(
     certs,
     date ?? +new Date(),
     crls,
   )
+  let pcesvn: number | null = chain.length > 0 ? chain[0].getPceSvn() : null
 
   // Use fallback certs, only if certdata is not provided
   if (!root && certs.length === 0) {
@@ -196,12 +197,15 @@ export async function _verifySgx(quote: Uint8Array, config?: VerifyConfig) {
     status = fallback.status
     root = fallback.root
     fmspc = fallback.fmspc
+    chain = fallback.chain
+    pcesvn = chain.length > 0 ? chain[0].getPceSvn() : null
   }
 
   return {
     status,
     root,
     fmspc,
+    pcesvn,
     signature,
     header,
     extraCertdata,

--- a/packages/qvl/test/qvl-sgx.test.ts
+++ b/packages/qvl/test/qvl-sgx.test.ts
@@ -58,12 +58,13 @@ test.serial("Verify an SGX quote from Intel, no quote signature", async (t) => {
     fs.readFileSync("test/sample/sgx/intermediateCaCrl.der"),
   ]
 
-  const { fmspc } = await _verifySgx(quote, {
+  const { fmspc, pcesvn } = await _verifySgx(quote, {
     crls: [],
     verifyTcb: () => true,
     extraCertdata: certdata,
   })
   t.is(fmspc, "00707f000000")
+  t.log(`PCESVN=${pcesvn}`)
 
   t.true(
     await verifySgx(quote, {
@@ -79,7 +80,7 @@ test.serial("Verify an SGX quote from Intel, no quote signature", async (t) => {
 test.serial("Verify an SGX quote from Occlum", async (t) => {
   const quote = fs.readFileSync("test/sample/sgx-occlum.dat")
   const { header, body } = parseSgxQuote(quote)
-  const { fmspc } = await _verifySgx(quote)
+  const { fmspc, pcesvn } = await _verifySgx(quote)
 
   const expectedMrEnclave =
     "9c90fd81f6e9fe64b46b14f0623523a52d6a5678482988c408f6adffe6301e2c"
@@ -91,6 +92,7 @@ test.serial("Verify an SGX quote from Occlum", async (t) => {
   t.is(hex(body.mr_enclave), expectedMrEnclave)
   t.is(hex(body.report_data), expectedReportData)
   t.is(fmspc, "30606a000000")
+  t.log(`PCESVN=${pcesvn}`)
 
   t.true(
     await verifySgx(quote, {
@@ -104,7 +106,7 @@ test.serial("Verify an SGX quote from Occlum", async (t) => {
 test.serial("Verify an SGX quote from chinenyeokafor", async (t) => {
   const quote = fs.readFileSync("test/sample/sgx-chinenyeokafor.dat")
   const { header, body } = parseSgxQuote(quote)
-  const { fmspc } = await _verifySgx(quote)
+  const { fmspc, pcesvn } = await _verifySgx(quote)
 
   const expectedMrEnclave =
     "0696ab235b2d339e68a4303cb64cde005bb8cdf2448bed742ac8ea8339bd0cb7"
@@ -116,6 +118,7 @@ test.serial("Verify an SGX quote from chinenyeokafor", async (t) => {
   t.is(hex(body.mr_enclave), expectedMrEnclave)
   t.is(hex(body.report_data), expectedReportData)
   t.is(fmspc, "90c06f000000")
+  t.log(`PCESVN=${pcesvn}`)
 
   t.true(
     await verifySgx(quote, {
@@ -129,7 +132,7 @@ test.serial("Verify an SGX quote from chinenyeokafor", async (t) => {
 test.serial("Verify an SGX quote from TLSN, quote9", async (t) => {
   const quote = fs.readFileSync("test/sample/sgx-tlsn-quote9.dat")
   const { header, body } = parseSgxQuote(quote)
-  const { fmspc } = await _verifySgx(quote)
+  const { fmspc, pcesvn } = await _verifySgx(quote)
 
   const expectedMrEnclave =
     "50a6a608c1972408f94379f83a7af2ea55b31095f131efe93af74f5968a44f29"
@@ -141,6 +144,7 @@ test.serial("Verify an SGX quote from TLSN, quote9", async (t) => {
   t.is(hex(body.mr_enclave), expectedMrEnclave)
   t.is(hex(body.report_data), expectedReportData)
   t.is(fmspc, "00906ed50000")
+  t.log(`PCESVN=${pcesvn}`)
 
   t.true(
     await verifySgx(quote, {
@@ -154,7 +158,7 @@ test.serial("Verify an SGX quote from TLSN, quote9", async (t) => {
 test.serial("Verify an SGX quote from TLSN, quote_dev", async (t) => {
   const quote = fs.readFileSync("test/sample/sgx-tlsn-quotedev.dat")
   const { header, body } = parseSgxQuote(quote)
-  const { fmspc } = await _verifySgx(quote)
+  const { fmspc, pcesvn } = await _verifySgx(quote)
 
   const expectedMrEnclave =
     "db5e55d3190d92512e4eae09d697b4b5fe30c2212e1ad6db5681379608c46204"
@@ -166,6 +170,7 @@ test.serial("Verify an SGX quote from TLSN, quote_dev", async (t) => {
   t.is(hex(body.mr_enclave), expectedMrEnclave)
   t.is(hex(body.report_data), expectedReportData)
   t.is(fmspc, "00906ed50000")
+  t.log(`PCESVN=${pcesvn}`)
 
   t.true(
     await verifySgx(quote, {

--- a/packages/qvl/test/qvl-tcb.test.ts
+++ b/packages/qvl/test/qvl-tcb.test.ts
@@ -51,6 +51,7 @@ function getVerifyTcb(stateRef: TcbRef) {
     pceSvn,
     quote,
   }: VerifyArgs): Promise<boolean> => {
+    console.log(`PCESVN=${pceSvn}`)
     // Fetch TCB info
     const isTdx = isTdxQuote(quote)
     const tcbInfo = await fetchTcbInfo(fmspc, isTdx)

--- a/packages/qvl/test/qvl-tdxv5.test.ts
+++ b/packages/qvl/test/qvl-tdxv5.test.ts
@@ -21,7 +21,7 @@ const BASE_TIME = Date.parse("2025-09-01")
 test.serial("Verify a V5 TDX quote from Trustee", async (t) => {
   const quote = fs.readFileSync("test/sample/tdx-v5-trustee.dat")
   const { header, body } = parseTdxQuote(quote)
-  const { fmspc } = await _verifyTdx(quote)
+  const { fmspc, pcesvn } = await _verifyTdx(quote)
 
   const expectedMRTD =
     "dfba221b48a22af8511542ee796603f37382800840dcd978703909bf8e64d4c8a1e9de86e7c9638bfcba422f3886400a"
@@ -36,6 +36,7 @@ test.serial("Verify a V5 TDX quote from Trustee", async (t) => {
   t.deepEqual(body.mr_owner, Buffer.alloc(48))
   t.deepEqual(body.mr_owner_config, Buffer.alloc(48))
   t.is(fmspc, "90c06f000000")
+  t.log(`PCESVN=${pcesvn}`)
 
   t.true(
     await verifyTdx(quote, {

--- a/packages/qvl/test/qvl.test.ts
+++ b/packages/qvl/test/qvl.test.ts
@@ -31,7 +31,8 @@ test.serial("Verify a V4 TDX quote from Tappd", async (t) => {
   const quote = Buffer.from(quoteHex.replace(/^0x/, ""), "hex")
 
   const { header, body } = parseTdxQuote(quote)
-  const { fmspc } = await _verifyTdx(quote)
+  const { fmspc, pcesvn } = await _verifyTdx(quote)
+  t.log(`PCESVN=${pcesvn}`)
 
   const expectedMRTD =
     "c68518a0ebb42136c12b2275164f8c72f25fa9a34392228687ed6e9caeb9c0f1dbd895e9cf475121c029dc47e70e91fd"
@@ -60,7 +61,8 @@ test.serial("Verify a V4 TDX quote from Edgeless", async (t) => {
   const quote = fs.readFileSync("test/sample/tdx-v4-edgeless.dat")
 
   const { header, body } = parseTdxQuote(quote)
-  const { fmspc } = await _verifyTdx(quote)
+  const { fmspc, pcesvn } = await _verifyTdx(quote)
+  t.log(`PCESVN=${pcesvn}`)
 
   const expectedMRTD =
     "b65ea009e424e6f761fdd3d7c8962439453b37ecdf62da04f7bc5d327686bb8bafc8a5d24a9c31cee60e4aba87c2f71b"
@@ -89,7 +91,8 @@ test.serial("Verify a V4 TDX quote from Phala, bin format", async (t) => {
   const quote = fs.readFileSync("test/sample/tdx-v4-phala.dat")
 
   const { header, body } = parseTdxQuote(quote)
-  const { fmspc } = await _verifyTdx(quote)
+  const { fmspc, pcesvn } = await _verifyTdx(quote)
+  t.log(`PCESVN=${pcesvn}`)
 
   const expectedMRTD =
     "91eb2b44d141d4ece09f0c75c2c53d247a3c68edd7fafe8a3520c942a604a407de03ae6dc5f87f27428b2538873118b7"
@@ -119,7 +122,8 @@ test.serial("Verify a V4 TDX quote from Phala, hex format", async (t) => {
   const quote = Buffer.from(quoteHex.replace(/^0x/, ""), "hex")
 
   const { header, body } = parseTdxQuote(quote)
-  const { fmspc } = await _verifyTdx(quote)
+  const { fmspc, pcesvn } = await _verifyTdx(quote)
+  t.log(`PCESVN=${pcesvn}`)
 
   const expectedMRTD =
     "7ba9e262ce6979087e34632603f354dd8f8a870f5947d116af8114db6c9d0d74c48bec4280e5b4f4a37025a10905bb29"
@@ -178,7 +182,8 @@ test.serial("Verify a V4 TDX quote from MoeMahhouk", async (t) => {
 test.serial("Verify a V4 TDX quote from Azure", async (t) => {
   const quote = fs.readFileSync("test/sample/tdx-v4-azure", "utf-8")
   const { header, body } = parseTdxQuoteBase64(quote)
-  const { fmspc } = await _verifyTdx(scureBase64.decode(quote))
+  const { fmspc, pcesvn } = await _verifyTdx(scureBase64.decode(quote))
+  t.log(`PCESVN=${pcesvn}`)
 
   const expectedMRTD =
     "fe27b2aa3a05ec56864c308aff03dd13c189a6112d21e417ec1afe626a8cb9d91482d1379ec02fe6308972950a930d0a"
@@ -206,7 +211,8 @@ test.serial("Verify a V4 TDX quote from Azure", async (t) => {
 test.serial("Verify a V4 TDX quote from Trustee", async (t) => {
   const quote = fs.readFileSync("test/sample/tdx-v4-trustee.dat")
   const { header, body } = parseTdxQuote(quote)
-  const { fmspc } = await _verifyTdx(quote)
+  const { fmspc, pcesvn } = await _verifyTdx(quote)
+  t.log(`PCESVN=${pcesvn}`)
 
   const expectedMRTD =
     "705ee9381b8633a9fbe532b52345e8433343d2868959f57889d84ca377c395b689cac1599ccea1b7d420483a9ce5f031"
@@ -294,12 +300,13 @@ test.serial("Verify a V4 TDX quote from Intel", async (t) => {
     fs.readFileSync("test/sample/tdx/intermediateCaCrl.der"),
   ]
 
-  const { fmspc } = await _verifyTdx(quote, {
+  const { fmspc, pcesvn } = await _verifyTdx(quote, {
     extraCertdata: certdata,
     crls,
     verifyTcb: () => true,
   })
   t.is(fmspc, "ed742af8adf5")
+  t.log(`PCESVN=${pcesvn}`)
 
   t.true(
     await verifyTdx(quote, {
@@ -318,7 +325,8 @@ test.serial("Verify a V4 TDX quote from GCP", async (t) => {
   )
   const quote: string = data.tdx.quote
   const { header, body } = parseTdxQuoteBase64(quote)
-  const { fmspc } = await _verifyTdx(scureBase64.decode(quote))
+  const { fmspc, pcesvn } = await _verifyTdx(scureBase64.decode(quote))
+  t.log(`PCESVN=${pcesvn}`)
 
   const expectedMRTD =
     "409c0cd3e63d9ea54d817cf851983a220131262664ac8cd02cc6a2e19fd291d2fdd0cc035d7789b982a43a92a4424c99"


### PR DESCRIPTION
Extract PCESVN from PCK certificates and surface it in SGX/TDX verification results and tests.

The `getPceSvn()` method was added to `QV_X509Certificate` to parse the specific X509 extension (sub-OID 1.2.840.113741.1.13.1.2.17). This value is now returned by `_verifySgx` and `_verifyTdx`, used in `verifyTdx`'s TCB check, and logged in relevant test cases for visibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-b1d6c6b7-cff2-487a-b5d0-1ead8aa1a709"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b1d6c6b7-cff2-487a-b5d0-1ead8aa1a709"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

