### PR TITLE
Assert tee_tcb_svn in qvl quote tests

### DIFF
--- a/packages/qvl/test/quote-sgx.test.ts
+++ b/packages/qvl/test/quote-sgx.test.ts
@@ -34,6 +34,7 @@ test.serial("Verify an SGX quote from Intel, no quote signature", async (t) => {
   t.deepEqual(body.mr_signer, Buffer.alloc(32))
   t.deepEqual(body.attributes, Buffer.alloc(16))
   t.deepEqual(body.cpu_svn, Buffer.alloc(16))
+  t.is(hex(body.cpu_svn), "00000000000000000000000000000000")
 
   t.is(
     hex(signature.ecdsa_signature),
@@ -91,6 +92,7 @@ test.serial("Verify an SGX quote from Occlum", async (t) => {
   t.is(header.tee_type, 0)
   t.is(hex(body.mr_enclave), expectedMrEnclave)
   t.is(hex(body.report_data), expectedReportData)
+  t.is(hex(body.cpu_svn), "0505090affff00000000000000000000")
   t.is(fmspc, "30606a000000")
   t.is(pcesvn, 11)
 
@@ -117,6 +119,7 @@ test.serial("Verify an SGX quote from chinenyeokafor", async (t) => {
   t.is(header.tee_type, 0)
   t.is(hex(body.mr_enclave), expectedMrEnclave)
   t.is(hex(body.report_data), expectedReportData)
+  t.is(hex(body.cpu_svn), "0202191b03ff00060000000000000000")
   t.is(fmspc, "90c06f000000")
   t.is(pcesvn, 13)
 
@@ -143,6 +146,7 @@ test.serial("Verify an SGX quote from TLSN, quote9", async (t) => {
   t.is(header.tee_type, 0)
   t.is(hex(body.mr_enclave), expectedMrEnclave)
   t.is(hex(body.report_data), expectedReportData)
+  t.is(hex(body.cpu_svn), "15150b07ff800e000000000000000000")
   t.is(fmspc, "00906ed50000")
   t.is(pcesvn, 13)
 
@@ -169,6 +173,7 @@ test.serial("Verify an SGX quote from TLSN, quote_dev", async (t) => {
   t.is(header.tee_type, 0)
   t.is(hex(body.mr_enclave), expectedMrEnclave)
   t.is(hex(body.report_data), expectedReportData)
+  t.is(hex(body.cpu_svn), "15150b07ff800e000000000000000000")
   t.is(fmspc, "00906ed50000")
   t.is(pcesvn, 13)
 

--- a/packages/qvl/test/quote-tdxv4.test.ts
+++ b/packages/qvl/test/quote-tdxv4.test.ts
@@ -48,6 +48,7 @@ test.serial("Verify a V4 TDX quote from Tappd", async (t) => {
   t.deepEqual(body.mr_config_id, Buffer.alloc(48))
   t.deepEqual(body.mr_owner, Buffer.alloc(48))
   t.deepEqual(body.mr_owner_config, Buffer.alloc(48))
+  t.is(hex(body.tee_tcb_svn), "05010200000000000000000000000000")
   t.is(fmspc, "b0c06f000000")
   t.is(pcesvn, 11)
 
@@ -78,6 +79,7 @@ test.serial("Verify a V4 TDX quote from Edgeless", async (t) => {
   t.deepEqual(body.mr_config_id, Buffer.alloc(48))
   t.deepEqual(body.mr_owner, Buffer.alloc(48))
   t.deepEqual(body.mr_owner_config, Buffer.alloc(48))
+  t.is(hex(body.tee_tcb_svn), "03000500000000000000000000000000")
   t.is(fmspc, "00806f050000")
   t.is(pcesvn, 11)
 
@@ -108,6 +110,7 @@ test.serial("Verify a V4 TDX quote from Phala, bin format", async (t) => {
   t.deepEqual(body.mr_config_id, Buffer.alloc(48))
   t.deepEqual(body.mr_owner, Buffer.alloc(48))
   t.deepEqual(body.mr_owner_config, Buffer.alloc(48))
+  t.is(hex(body.tee_tcb_svn), "06010300000000000000000000000000")
   t.is(fmspc, "b0c06f000000")
   t.is(pcesvn, 11)
 
@@ -142,6 +145,7 @@ test.serial("Verify a V4 TDX quote from Phala, hex format", async (t) => {
   t.deepEqual(body.mr_config_id, Buffer.alloc(48))
   t.deepEqual(body.mr_owner, Buffer.alloc(48))
   t.deepEqual(body.mr_owner_config, Buffer.alloc(48))
+  t.is(hex(body.tee_tcb_svn), "05010200000000000000000000000000")
   t.is(fmspc, "b0c06f000000")
   t.is(pcesvn, 11)
 
@@ -174,6 +178,7 @@ test.serial("Verify a V4 TDX quote from MoeMahhouk", async (t) => {
   t.deepEqual(body.mr_config_id, Buffer.alloc(48))
   t.deepEqual(body.mr_owner, Buffer.alloc(48))
   t.deepEqual(body.mr_owner_config, Buffer.alloc(48))
+  t.is(hex(body.tee_tcb_svn), "04010200000000000000000000000000")
   t.is(fmspc, "90c06f000000")
   t.is(pcesvn, 13)
 
@@ -203,6 +208,7 @@ test.serial("Verify a V4 TDX quote from Azure", async (t) => {
   t.deepEqual(body.mr_config_id, new Uint8Array(48))
   t.deepEqual(body.mr_owner, new Uint8Array(48))
   t.deepEqual(body.mr_owner_config, new Uint8Array(48))
+  t.is(hex(body.tee_tcb_svn), "04010700000000000000000000000000")
   t.is(fmspc, "00806f050000")
   t.is(pcesvn, 11)
 
@@ -232,6 +238,7 @@ test.serial("Verify a V4 TDX quote from Trustee", async (t) => {
   t.deepEqual(body.mr_config_id, Buffer.alloc(48))
   t.deepEqual(body.mr_owner, Buffer.alloc(48))
   t.deepEqual(body.mr_owner_config, Buffer.alloc(48))
+  t.is(hex(body.tee_tcb_svn), "03000500000000000000000000000000")
   t.is(fmspc, "50806f000000")
   t.is(pcesvn, 11)
 
@@ -261,6 +268,7 @@ test.serial("Verify a V4 TDX quote from ZKDCAP", async (t) => {
   t.deepEqual(body.mr_config_id, Buffer.alloc(48))
   t.deepEqual(body.mr_owner, Buffer.alloc(48))
   t.deepEqual(body.mr_owner_config, Buffer.alloc(48))
+  t.is(hex(body.tee_tcb_svn), "04010700000000000000000000000000")
   t.is(fmspc, "00806f050000")
   t.is(pcesvn, 11)
 
@@ -289,6 +297,7 @@ test.serial("Verify a V4 TDX quote from Intel", async (t) => {
   t.deepEqual(body.mr_config_id, Buffer.alloc(48))
   t.deepEqual(body.mr_owner, Buffer.alloc(48))
   t.deepEqual(body.mr_owner_config, Buffer.alloc(48))
+  t.is(hex(body.tee_tcb_svn), "52c1a38cf7edf30a524b4ebb049f59c7")
 
   // Intel sample is missing certdata, reconstruct it from provided PEM files instead
   const root = extractPemCertificates(
@@ -347,6 +356,7 @@ test.serial("Verify a V4 TDX quote from GCP", async (t) => {
   t.deepEqual(body.mr_config_id, new Uint8Array(48))
   t.deepEqual(body.mr_owner, new Uint8Array(48))
   t.deepEqual(body.mr_owner_config, new Uint8Array(48))
+  t.is(hex(body.tee_tcb_svn), "08010800000000000000000000000000")
   t.is(fmspc, "00806f050000")
   t.is(pcesvn, 11)
 

--- a/packages/qvl/test/quote-tdxv5.test.ts
+++ b/packages/qvl/test/quote-tdxv5.test.ts
@@ -35,6 +35,7 @@ test.serial("Verify a V5 TDX quote from Trustee", async (t) => {
   t.deepEqual(body.mr_config_id, Buffer.alloc(48))
   t.deepEqual(body.mr_owner, Buffer.alloc(48))
   t.deepEqual(body.mr_owner_config, Buffer.alloc(48))
+  t.is(hex(body.tee_tcb_svn), "05010200000000000000000000000000")
   t.is(fmspc, "90c06f000000")
   t.is(pcesvn, 13)
 


### PR DESCRIPTION
Add assertions for `tee_tcb_svn` and `cpu_svn` in all positive SGX and TDX quote tests.

This improves test coverage by ensuring the correct TCB SVN values are present in the parsed quotes for both SGX (`cpu_svn`) and TDX (`tee_tcb_svn`) environments.

---
<a href="https://cursor.com/background-agent?bcId=bc-daa27d3c-b062-42c3-b63e-b73702b70218"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-daa27d3c-b062-42c3-b63e-b73702b70218"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

